### PR TITLE
Fix/intervention sliders

### DIFF
--- a/src/components/LC-cases.tsx
+++ b/src/components/LC-cases.tsx
@@ -114,14 +114,6 @@ export function LCCases() {
       ...prev,
       [id]: checked,
     }));
-
-    // reset intervention value when unchecking
-    if (!checked) {
-      setInterventionValues((prev) => ({
-        ...prev,
-        [id]: 0,
-      }));
-    }
   };
 
   const handleSliderValueChange = (id: string, value: number[]) => {

--- a/src/components/LC-cases.tsx
+++ b/src/components/LC-cases.tsx
@@ -114,6 +114,21 @@ export function LCCases() {
       ...prev,
       [id]: checked,
     }));
+
+    // reset intervention value when unchecking
+    if (!checked) {
+      setInterventionValues((prev) => ({
+        ...prev,
+        [id]: 0,
+      }));
+    }
+  };
+
+  const handleSliderValueChange = (id: string, value: number[]) => {
+    setInterventionValues((prev) => ({
+      ...prev,
+      [id]: value[0],
+    }));
   };
 
   const filteredData = calculateReducedCases(
@@ -296,12 +311,9 @@ export function LCCases() {
                             initialValue={[0]}
                             defaultValue={[0]}
                             disabled={!interventions.sickLeave}
-                            onValueChange={(value) => {
-                              setInterventionValues((prev) => ({
-                                ...prev,
-                                sickLeave: value[0],
-                              }));
-                            }}
+                            onValueChange={(value) =>
+                              handleSliderValueChange("sickLeave", value)
+                            }
                           />
                         </div>
                       </div>
@@ -332,12 +344,9 @@ export function LCCases() {
                             initialValue={[0]}
                             defaultValue={[0]}
                             disabled={!interventions.ventilation}
-                            onValueChange={(value) => {
-                              setInterventionValues((prev) => ({
-                                ...prev,
-                                ventilation: value[0],
-                              }));
-                            }}
+                            onValueChange={(value) =>
+                              handleSliderValueChange("ventilation", value)
+                            }
                           />
                         </div>
                       </div>
@@ -368,12 +377,9 @@ export function LCCases() {
                             initialValue={[0]}
                             defaultValue={[0]}
                             disabled={!interventions.testing}
-                            onValueChange={(value) => {
-                              setInterventionValues((prev) => ({
-                                ...prev,
-                                testing: value[0],
-                              }));
-                            }}
+                            onValueChange={(value) =>
+                              handleSliderValueChange("testing", value)
+                            }
                           />
                         </div>
                       </div>
@@ -404,12 +410,9 @@ export function LCCases() {
                             initialValue={[0]}
                             defaultValue={[0]}
                             disabled={!interventions.vaccination}
-                            onValueChange={(value) => {
-                              setInterventionValues((prev) => ({
-                                ...prev,
-                                vaccination: value[0],
-                              }));
-                            }}
+                            onValueChange={(value) =>
+                              handleSliderValueChange("vaccination", value)
+                            }
                           />
                         </div>
                       </div>
@@ -437,12 +440,9 @@ export function LCCases() {
                             initialValue={[0]}
                             defaultValue={[0]}
                             disabled={!interventions.masks}
-                            onValueChange={(value) => {
-                              setInterventionValues((prev) => ({
-                                ...prev,
-                                masks: value[0],
-                              }));
-                            }}
+                            onValueChange={(value) =>
+                              handleSliderValueChange("masks", value)
+                            }
                           />
                         </div>
                       </div>
@@ -476,12 +476,12 @@ export function LCCases() {
                             initialValue={[0]}
                             defaultValue={[0]}
                             disabled={!interventions.pharmaceuticalprevention}
-                            onValueChange={(value) => {
-                              setInterventionValues((prev) => ({
-                                ...prev,
-                                pharmaceuticalprevention: value[0],
-                              }));
-                            }}
+                            onValueChange={(value) =>
+                              handleSliderValueChange(
+                                "pharmaceuticalprevention",
+                                value,
+                              )
+                            }
                           />
                         </div>
                       </div>

--- a/src/components/interventions-slider.tsx
+++ b/src/components/interventions-slider.tsx
@@ -44,7 +44,13 @@ function InterventionsSlider({
     handleInputChange,
     handleSliderChange,
     resetToDefault,
-  } = useSliderWithInput({ minValue, maxValue, initialValue, defaultValue });
+  } = useSliderWithInput({
+    minValue,
+    maxValue,
+    initialValue,
+    defaultValue,
+    onValueChange,
+  });
 
   return (
     <div className={cn("min-w-[300px] space-y-3", className)}>

--- a/src/hooks/use-slider-with-input.tsx
+++ b/src/hooks/use-slider-with-input.tsx
@@ -5,6 +5,7 @@ type UseSliderWithInputProps = {
   maxValue?: number;
   initialValue?: number[];
   defaultValue?: number[];
+  onValueChange?: (value: number[]) => void;
 };
 
 export function useSliderWithInput({
@@ -12,6 +13,7 @@ export function useSliderWithInput({
   maxValue = 100,
   initialValue = [minValue],
   defaultValue = [minValue],
+  onValueChange,
 }: UseSliderWithInputProps) {
   const [sliderValue, setSliderValue] = useState(initialValue);
   const [inputValues, setInputValues] = useState(
@@ -57,8 +59,10 @@ export function useSliderWithInput({
       const newInputValues = [...inputValues];
       newInputValues[index] = clampedValue.toString();
       setInputValues(newInputValues);
+
+      onValueChange?.(newSliderValues);
     },
-    [sliderValue, inputValues, minValue, maxValue],
+    [sliderValue, inputValues, minValue, maxValue, onValueChange],
   );
 
   const handleInputChange = useCallback(
@@ -73,15 +77,20 @@ export function useSliderWithInput({
     [inputValues],
   );
 
-  const handleSliderChange = useCallback((newValue: number[]) => {
-    setSliderValue(newValue);
-    setInputValues(newValue.map((v) => v.toString()));
-  }, []);
+  const handleSliderChange = useCallback(
+    (newValue: number[]) => {
+      setSliderValue(newValue);
+      setInputValues(newValue.map((v) => v.toString()));
+      onValueChange?.(newValue);
+    },
+    [onValueChange],
+  );
 
   const resetToDefault = useCallback(() => {
     setSliderValue(defaultValue);
     setInputValues(defaultValue.map((v) => v.toString()));
-  }, [defaultValue]);
+    onValueChange?.(defaultValue);
+  }, [defaultValue, onValueChange]);
 
   return {
     sliderValue,


### PR DESCRIPTION
fixes #35 

- reset button on slider resets chart to original position
- if slider holds a non-default value then checkbox is unchecked, chart returns to original position
  - if checkbox is then re-checked, chart returns to value slider holds
- after slider button is reset, if checkbox is checked or unchecked the chart remains the same (the value of the slider is 0)