### PR TITLE
Compare interventions

### DIFF
--- a/src/components/LC-DALYs.tsx
+++ b/src/components/LC-DALYs.tsx
@@ -290,10 +290,6 @@ const chartDataItems = generateChartDataItems();
 //   },
 // } satisfies ChartConfig;
 
-// to do: checkboxes no longer enable or disable sliders.
-// instead, checkboxes will enable a "comparison mode". Each time you click a checkbox, it adds that intervention to the chart as its own line.
-// this way, a user can compare various interventions against each other, and the baseline.
-
 /**
  * Calculates the reduced DALYs based on selected interventions and their slider values.
  * @param baseData - The baseline chart data (no intervention).
@@ -351,6 +347,7 @@ export function LCDALYs() {
         color: "hsl(var(--chart-2))",
       };
     }
+    console.log("chartConfig", config);
 
     return config;
   }, [isComparativeMode, interventionSliderValues]);
@@ -569,7 +566,7 @@ export function LCDALYs() {
                 setIsComparativeMode(checked as boolean)
               }
             />
-            <label htmlFor="comparative-mode">Comparative Mode</label>
+            <label htmlFor="comparative-mode">Compare Interventions</label>
           </div>
           {Object.entries(groupedInterventions).map(
             ([group, groupInterventions]) => (

--- a/src/components/LC-DALYs.tsx
+++ b/src/components/LC-DALYs.tsx
@@ -24,7 +24,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { InterventionArea } from "@/components/intervention-area";
+import { Checkbox } from "./ui/checkbox";
 
+/**
+ * Defines categories into which multiple interventions are grouped.
+ */
 const GROUP_LABELS: Record<string, string> = {
   air: "Air Quality improvements",
   masking: "Masking",
@@ -46,6 +50,9 @@ interface Intervention {
   reductionFn: (sliderValue: number) => number;
 }
 
+/**
+ * List of interventions to display. Add or remove interventions here.
+ */
 const INTERVENTIONS: Intervention[] = [
   {
     key: "airExchangeRate",
@@ -228,6 +235,9 @@ const INTERVENTIONS: Intervention[] = [
   },
 ];
 
+/**
+ * Groups interventions by their category for display purposes.
+ */
 const groupedInterventions = INTERVENTIONS.reduce(
   (acc, intervention) => {
     if (!acc[intervention.group]) acc[intervention.group] = [];
@@ -237,8 +247,19 @@ const groupedInterventions = INTERVENTIONS.reduce(
   {} as Record<string, Intervention[]>,
 );
 
-const generateChartData = () => {
-  const data = [];
+interface ChartDataItem {
+  date: string;
+  dalys: number;
+  [key: string]: number | string;
+}
+
+/**
+ * Generates the baseline chart data for Long COVID DALYs.
+ * Starts with 17 million cases and reduces by 2% each year.
+ * Each case contributes 80 DALYs per 1,000 people.
+ */
+const generateChartDataItems = () => {
+  const data: ChartDataItem[] = [];
   let baselineCases = 17000000; // Starting with 17M cases
   const yearlyReduction = 0.98; // 2% reduction per year
   // 80 DALYs per 1k people with LC
@@ -256,44 +277,46 @@ const generateChartData = () => {
   return data;
 };
 
-const chartData = generateChartData();
+const chartDataItems = generateChartDataItems();
 
-const chartConfig = {
-  dalys: {
-    label: "Million DALYs per year",
-    color: "hsl(var(--chart-1))",
-  },
-  interventionDalys: {
-    label: "With interventions",
-    color: "hsl(var(--chart-2))",
-  },
-} satisfies ChartConfig;
+// const chartConfig = {
+//   dalys: {
+//     label: "Million DALYs per year",
+//     color: "hsl(var(--chart-1))",
+//   },
+//   interventionDalys: {
+//     label: "With interventions",
+//     color: "hsl(var(--chart-2))",
+//   },
+// } satisfies ChartConfig;
 
+// to do: checkboxes no longer enable or disable sliders.
+// instead, checkboxes will enable a "comparison mode". Each time you click a checkbox, it adds that intervention to the chart as its own line.
+// this way, a user can compare various interventions against each other, and the baseline.
+
+/**
+ * Calculates the reduced DALYs based on selected interventions and their slider values.
+ * @param baseData - The baseline chart data (no intervention).
+ * @param interventionIsChecked - Object indicating which interventions are checked.
+ * @param interventionSliderValues - Object containing slider values for each intervention.
+ * @returns The modified chart data with reduced DALYs.
+ */
 const calculateReducedDALYs = (
-  baseData: typeof chartData,
-  interventionIsChecked: Record<string, boolean>,
+  item: ChartDataItem,
   interventionSliderValues: Record<string, number>,
 ) => {
   let reductionFactor = 0;
   for (const intervention of INTERVENTIONS) {
-    if (interventionIsChecked[intervention.key]) {
-      const sliderValue = interventionSliderValues[intervention.key];
-      reductionFactor += intervention.reductionFn(sliderValue);
-    }
+    const sliderValue = interventionSliderValues[intervention.key];
+    reductionFactor += intervention.reductionFn(sliderValue);
   }
 
-  return baseData.map((item) => ({
-    date: item.date,
-    dalys: Math.round(item.dalys * (1 - reductionFactor)),
-  }));
+  return Math.round(item.dalys * (1 - reductionFactor));
 };
 
 export function LCDALYs() {
   const [timeRange, setTimeRange] = React.useState("5y");
-
-  const initialInterventionCheckBoxStatus = Object.fromEntries(
-    INTERVENTIONS.map((intervention) => [intervention.key, false]),
-  );
+  const [isComparativeMode, setIsComparativeMode] = React.useState(false);
 
   const initialInterventionValues = Object.fromEntries(
     INTERVENTIONS.map((intervention) => [
@@ -302,19 +325,35 @@ export function LCDALYs() {
     ]),
   );
 
-  const [interventionIsChecked, setInterventionIsChecked] = React.useState(
-    initialInterventionCheckBoxStatus,
-  );
-
   const [interventionSliderValues, setInterventionSliderValues] =
     React.useState(initialInterventionValues);
 
-  const handleInterventionChange = (id: string, checked: boolean) => {
-    setInterventionIsChecked((prev) => ({
-      ...prev,
-      [id]: checked,
-    }));
-  };
+  // loop through interventions and create a chart config for each
+  const chartConfig: ChartConfig = React.useMemo(() => {
+    const config: ChartConfig = {
+      dalys: {
+        label: "Baseline DALYs (no intervention)",
+        color: "hsl(var(--chart-1))",
+      },
+    };
+    if (isComparativeMode) {
+      INTERVENTIONS.forEach((intervention, index) => {
+        if (interventionSliderValues[intervention.key] > 0) {
+          config[intervention.key] = {
+            label: intervention.sliderLabel,
+            color: `hsl(var(--chart-${index + 3}))`,
+          };
+        }
+      });
+    } else {
+      config.interventionDalys = {
+        label: "Intervention DALYs",
+        color: "hsl(var(--chart-2))",
+      };
+    }
+
+    return config;
+  }, [isComparativeMode, interventionSliderValues]);
 
   const handleSliderValueChange = (id: string, value: number[]) => {
     setInterventionSliderValues((prev) => ({
@@ -323,40 +362,42 @@ export function LCDALYs() {
     }));
   };
 
-  const filteredData = chartData
-    .map((baselineItem) => {
-      const date = baselineItem.date;
-      const interventionDalys = calculateReducedDALYs(
-        [baselineItem],
-        interventionIsChecked,
-        interventionSliderValues,
-      )[0].dalys;
+  const durationToEndDate: Record<string, Date> = {
+    "5y": new Date("2029-01-01"),
+    "10y": new Date("2034-01-01"),
+  };
 
-      return {
-        date,
-        dalys: baselineItem.dalys,
-        interventionDalys,
+  const filteredData = chartDataItems
+    .map((chartDataItem) => {
+      const modifiedDataItem: ChartDataItem = {
+        ...chartDataItem,
       };
+
+      if (isComparativeMode) {
+        // add each intervention's DALYs to the modified data item
+        INTERVENTIONS.forEach((intervention) => {
+          const sliderValue = interventionSliderValues[intervention.key];
+          modifiedDataItem[intervention.key] = Math.round(
+            chartDataItem.dalys *
+              (1 -
+                (sliderValue > 0 ? intervention.reductionFn(sliderValue) : 0)),
+          );
+        });
+      } else {
+        // in cumulative mode, we only add the interventionDalys
+        const interventionDalys = calculateReducedDALYs(
+          chartDataItem,
+          interventionSliderValues,
+        );
+        modifiedDataItem.interventionDalys = interventionDalys;
+      }
+
+      return modifiedDataItem;
     })
     .filter((item) => {
       const date = new Date(item.date);
       const startDate = new Date("2025-01-01");
-      let endDate = new Date("2029-01-01");
-
-      switch (timeRange) {
-        case "10y":
-          endDate = new Date("2034-01-01");
-          break;
-        case "25y":
-          endDate = new Date("2049-01-01");
-          break;
-        case "50y":
-          endDate = new Date("2074-01-01");
-          break;
-        case "100y":
-          endDate = new Date("2124-01-01");
-          break;
-      }
+      const endDate = durationToEndDate[timeRange];
       return date >= startDate && date <= endDate;
     });
 
@@ -396,15 +437,6 @@ export function LCDALYs() {
             </SelectItem>
             <SelectItem value="10y" className="rounded-lg">
               10 Year Projection
-            </SelectItem>
-            <SelectItem value="25y" className="rounded-lg">
-              25 Year Projection
-            </SelectItem>
-            <SelectItem value="50y" className="rounded-lg">
-              50 Year Projection
-            </SelectItem>
-            <SelectItem value="100y" className="rounded-lg">
-              100 Year Projection
             </SelectItem>
           </SelectContent>
         </Select>
@@ -501,7 +533,17 @@ export function LCDALYs() {
                 />
               }
             />
-            <Area
+            {Object.entries(chartConfig).map(([key]) => (
+              <Area
+                key={key}
+                dataKey={key}
+                type="natural"
+                fill={`url(#fill${key})`}
+                stroke={`var(--color-${key})`}
+              />
+            ))}
+            {/* 
+                        <Area
               dataKey="dalys"
               type="natural"
               fill="url(#filldalys)"
@@ -513,9 +555,22 @@ export function LCDALYs() {
               fill="url(#fillInterventionDalys)"
               stroke="var(--color-interventionDalys)"
             />
+
+            */}
           </AreaChart>
         </ChartContainer>
         <div className="mt-4 space-y-8">
+          {/* checkbox for comparative mode vs cumulative mode */}
+          <div className="flex items-center justify-center gap-4">
+            <Checkbox
+              id="comparative-mode"
+              checked={isComparativeMode}
+              onCheckedChange={(checked) =>
+                setIsComparativeMode(checked as boolean)
+              }
+            />
+            <label htmlFor="comparative-mode">Comparative Mode</label>
+          </div>
           {Object.entries(groupedInterventions).map(
             ([group, groupInterventions]) => (
               <div key={group}>
@@ -527,13 +582,6 @@ export function LCDALYs() {
                     <InterventionArea
                       key={intervention.key}
                       id={intervention.key}
-                      checked={interventionIsChecked[intervention.key]}
-                      onCheckedChange={(checked) =>
-                        handleInterventionChange(
-                          intervention.key,
-                          checked as boolean,
-                        )
-                      }
                       ariaLabel={intervention.ariaLabel}
                       sliderLabel={intervention.sliderLabel}
                       sliderSubLabel={intervention.sliderSubLabel}
@@ -542,7 +590,7 @@ export function LCDALYs() {
                       sliderStep={intervention.sliderStep}
                       sliderInitialValue={intervention.defaultValue}
                       sliderDefaultValue={intervention.defaultValue}
-                      sliderDisabled={!interventionIsChecked[intervention.key]}
+                      sliderDisabled={false}
                       onSliderChange={(value) =>
                         handleSliderValueChange(intervention.key, value)
                       }

--- a/src/components/LC-DALYs.tsx
+++ b/src/components/LC-DALYs.tsx
@@ -347,7 +347,6 @@ export function LCDALYs() {
         color: "hsl(var(--chart-2))",
       };
     }
-    console.log("chartConfig", config);
 
     return config;
   }, [isComparativeMode, interventionSliderValues]);

--- a/src/components/intervention-area.tsx
+++ b/src/components/intervention-area.tsx
@@ -1,10 +1,7 @@
-import { Checkbox } from "@/components/ui/checkbox";
 import { InterventionsSlider } from "@/components/interventions-slider";
 
 interface InterventionAreaProps {
   id: string;
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
   ariaLabel?: string;
   sliderLabel: string;
   sliderSubLabel: string;
@@ -19,8 +16,6 @@ interface InterventionAreaProps {
 
 export function InterventionArea({
   id,
-  checked,
-  onCheckedChange,
   ariaLabel,
   sliderLabel,
   sliderSubLabel,
@@ -34,7 +29,6 @@ export function InterventionArea({
 }: InterventionAreaProps) {
   return (
     <div className="mt-4 flex gap-x-4 text-left">
-      <Checkbox id={id} checked={checked} onCheckedChange={onCheckedChange} />
       <div className="grid w-full gap-0.5 leading-none">
         <label htmlFor={id} className="sr-only">
           {ariaLabel}

--- a/src/index.css
+++ b/src/index.css
@@ -30,13 +30,20 @@
     --radius: 0.5rem;
     /* Chart colors */
     /* rose 600 */
-    --chart-1: 346.8 77.2% 49.8%;
-    /* rose 50 */
-    --chart-2: 355.7 100% 97.3%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    /* todo add various colors */
+    --chart-1: 346.8 77.2% 49.8%; /* Base rose color */
+    --chart-2: 200 75% 45%; /* Ocean blue */
+    --chart-3: 150 65% 40%; /* Forest green */
+    --chart-4: 270 65% 50%; /* Royal purple */
+    --chart-5: 30 80% 45%; /* Burnt orange */
+    --chart-6: 180 70% 45%; /* Teal */
+    --chart-7: 320 65% 45%; /* Magenta */
+    --chart-8: 60 75% 45%; /* Gold */
+    --chart-9: 240 65% 45%; /* Navy blue */
+    --chart-10: 100 65% 45%; /* Lime green */
+    --chart-11: 0 75% 45%; /* Cherry red */
+    --chart-12: 210 70% 45%; /* Steel blue */
+    --chart-13: 290 65% 45%; /* Plum */
+    --chart-14: 160 70% 45%; /* Emerald */
   }
 
   .dark {
@@ -61,13 +68,20 @@
     --ring: 0 0% 83.1%;
 
     /* Chart colors for dark mode */
-    /* red 400 */
-    --chart-1: 0 90.6% 70.8%;
-    /* red 100 */
-    --chart-2: 0 93.3% 94.1%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+    --chart-1: 0 90.6% 70.8%; /* Base red */
+    --chart-2: 200 85% 65%; /* Bright blue */
+    --chart-3: 150 75% 60%; /* Bright green */
+    --chart-4: 270 75% 65%; /* Bright purple */
+    --chart-5: 30 85% 65%; /* Bright orange */
+    --chart-6: 180 80% 65%; /* Bright teal */
+    --chart-7: 320 75% 65%; /* Bright pink */
+    --chart-8: 60 85% 65%; /* Bright yellow */
+    --chart-9: 240 75% 65%; /* Bright navy */
+    --chart-10: 100 75% 65%; /* Bright lime */
+    --chart-11: 0 85% 65%; /* Bright red */
+    --chart-12: 210 80% 65%; /* Bright azure */
+    --chart-13: 290 75% 65%; /* Bright violet */
+    --chart-14: 160 80% 65%; /* Bright mint */
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,7 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
+    /* todo add various colors */
   }
 
   .dark {


### PR DESCRIPTION
- change year dropdown for x axis to only include 5 years and 10 years
- introduce cumulative and comparative mode:  
  - default behavior is that adjusting sliders adds the effects of various interventions, aka "cumulative mode"
  - with "compare interventions" checked, moving each slider adds a new line to the chart for that intervention, aka "comparative mode"
